### PR TITLE
[fix](load) add missing flush context for BetaRowsetWriter::_add_block()

### DIFF
--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -492,7 +492,7 @@ Status BetaRowsetWriter::flush_single_memtable(const vectorized::Block* block, i
     std::unique_ptr<segment_v2::SegmentWriter> writer;
     RETURN_IF_ERROR(_create_segment_writer(&writer, ctx));
     int32_t segment_id = writer->get_segment_id();
-    RETURN_IF_ERROR(_add_block(block, &writer));
+    RETURN_IF_ERROR(_add_block(block, &writer, ctx));
     RETURN_IF_ERROR(_flush_segment_writer(&writer, flush_size));
     if (ctx != nullptr && ctx->generate_delete_bitmap) {
         RETURN_IF_ERROR(ctx->generate_delete_bitmap(segment_id));


### PR DESCRIPTION
## Proposed changes

If `segment_id` is set in flush context, we expect entire memtable being flushed into one segment.

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

